### PR TITLE
Add IL for more math opcodes

### DIFF
--- a/lvjit/LuaFunctionBuilder.cpp
+++ b/lvjit/LuaFunctionBuilder.cpp
@@ -185,31 +185,6 @@ StkId vm_newtable(lua_State* L, Instruction i) {
    return base;
 }
 
-StkId vm_sub(lua_State* L, Instruction i) {
-   // prologue
-   CallInfo *ci = L->ci;
-   LClosure *cl = clLvalue(ci->func);
-   TValue *k = cl->p->k;
-   StkId base = ci->u.l.base;
-   StkId ra = RA(i);
-
-   // main body
-   TValue *rb = RKB(i);
-   TValue *rc = RKC(i);
-   lua_Number nb; lua_Number nc;
-   if (ttisinteger(rb) && ttisinteger(rc)) {
-     lua_Integer ib = ivalue(rb); lua_Integer ic = ivalue(rc);
-     setivalue(ra, intop(-, ib, ic));
-   }
-   else if (tonumber(rb, &nb) && tonumber(rc, &nc)) {
-     setfltvalue(ra, luai_numsub(L, nb, nc));
-   }
-   else { Protect(luaT_trybinTM(L, rb, rc, ra, TM_SUB)); }
-
-   // epilogue
-   return base;
-}
-
 StkId vm_mul(lua_State* L, Instruction i) {
    // prologue
    CallInfo *ci = L->ci;
@@ -766,11 +741,6 @@ Lua::FunctionBuilder::FunctionBuilder(Proto* p, Lua::TypeDictionary* types)
                   plua_State,
                   luaTypes.Instruction);
 
-   DefineFunction("vm_sub", __FILE__, "0", (void*)vm_sub,
-                  luaTypes.StkId, 2,
-                  plua_State,
-                  luaTypes.Instruction);
-
    DefineFunction("vm_mul", __FILE__, "0", (void*)vm_mul,
                   luaTypes.StkId, 2,
                   plua_State,
@@ -1212,10 +1182,56 @@ bool Lua::FunctionBuilder::do_add(TR::BytecodeBuilder* builder, Instruction inst
 }
 
 bool Lua::FunctionBuilder::do_sub(TR::BytecodeBuilder* builder, Instruction instruction) {
-   builder->Store("base",
-   builder->      Call("vm_sub", 2,
-   builder->           Load("L"),
-   builder->           ConstInt32(instruction)));
+   // rb = RKB(i);
+   // rc = RKC(i);
+   builder->Store("rb", jit_RK(builder, GETARG_B(instruction)));
+   builder->Store("rc", jit_RK(builder, GETARG_C(instruction)));
+
+   // if (ttisinteger(rb) && ttisinteger(rc))
+   auto isrbint = jit_checktag(builder, builder->Load("rb"), LUA_TNUMINT);
+   auto isrcint = jit_checktag(builder, builder->Load("rc"), LUA_TNUMINT);
+
+   auto addints = builder->OrphanBuilder();
+   auto notints = builder->OrphanBuilder();
+   builder->IfThenElse(&addints, &notints, builder->And(isrbint, isrcint));
+
+   // lua_Integer ib = ivalue(rb); lua_Integer ic = ivalue(rc);
+   // setivalue(ra, intop(-, ib, ic));
+   auto intsum = addints->Sub(
+                 addints->    LoadIndirect("TValue_i", "value_",
+                 addints->                 Load("rb")),
+                 addints->    LoadIndirect("TValue_i", "value_",
+                 addints->                 Load("rc")));
+   addints->StoreIndirect("TValue_i", "value_",
+   addints->              Load("ra"),
+                          intsum);
+   addints->StoreIndirect("TValue_i", "tt_", addints->Load("ra"), addints->Const(LUA_TNUMINT));
+
+   // else if (ttisnumber(rb) && ttisnumber(rc))
+   auto isrbnum = jit_masktag(notints, notints->Load("rb"), LUA_TNUMBER);
+   auto isrcnum = jit_masktag(notints, notints->Load("rc"), LUA_TNUMBER);
+
+   auto addnums = notints->OrphanBuilder();
+   auto notnums = notints->OrphanBuilder();
+   notints->IfThenElse(&addnums, &notnums, notints->And(isrbnum, isrcnum));
+
+   // setfltvalue(ra, luai_numsub(L,tonumber(rb), tonumber(rc)));
+   auto numsum = addnums->Sub(
+                 jit_tonumber(addnums, addnums->Load("rb")),
+                 jit_tonumber(addnums, addnums->Load("rc")));
+   addnums->StoreIndirect("TValue_n", "value_",
+   addnums->              Load("ra"),
+                          numsum);
+   addnums->StoreIndirect("TValue_n", "tt_", addnums->Load("ra"), addnums->Const(LUA_TNUMFLT));
+
+   // else { Protect(luaT_trybinTM(L, rb, rc, ra, TM_SUB)); }
+   notnums->Call("luaT_trybinTM", 5,
+   notnums->     Load("L"),
+   notnums->     Load("rb"),
+   notnums->     Load("rc"),
+   notnums->     Load("ra"),
+   notnums->     Const(TM_SUB));
+   jit_Protect(notnums);
 
    return true;
 }


### PR DESCRIPTION
After the OP_ADD opcode was modified to generate IL instead of calling a VM helper I used it as an example to implement OP_SUB, OP_MUL and OP_DIV.  I removed the vm_* helpers for these 3 opcodes.

This is 3 of the 4 opcodes that were discussed in Issue #6.  I will investigate idiv next as it was more complicated since it requires the floor of the values.