### PR TITLE
Create a common do_math helper

### DIFF
--- a/lvjit/LuaFunctionBuilder.hpp
+++ b/lvjit/LuaFunctionBuilder.hpp
@@ -56,9 +56,7 @@ public:
 
     bool do_newtable(TR::BytecodeBuilder* builder, Instruction instruction);
 
-    bool do_add(TR::BytecodeBuilder* builder, Instruction instruction);
-    bool do_sub(TR::BytecodeBuilder* builder, Instruction instruction);
-    bool do_mul(TR::BytecodeBuilder* builder, Instruction instruction);
+    bool do_math(TR::BytecodeBuilder* builder, Instruction instruction);
     bool do_mod(TR::BytecodeBuilder* builder, Instruction instruction);
     bool do_pow(TR::BytecodeBuilder* builder, Instruction instruction);
     bool do_div(TR::BytecodeBuilder* builder, Instruction instruction);


### PR DESCRIPTION
Almost 100% of the code for OP_ADD, OP_SUB and OP_MUL is identical. This
means that there are 3 functions with exactly the same code except for
the actual math operation.

This change creates a do_math helper which handles all 3 of the opcodes
above.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>