### PR TITLE
Generate IL for loops, code cleanup and perf improvements

### DIFF
--- a/lvjit/LuaFunctionBuilder.cpp
+++ b/lvjit/LuaFunctionBuilder.cpp
@@ -964,9 +964,10 @@ bool Lua::FunctionBuilder::do_loadnil(TR::BytecodeBuilder* builder, Instruction 
    setnils->StoreIndirect("TValue", "tt_",
    setnils->              Load("ra"),
    setnils->              ConstInt32(LUA_TNIL));
-   setnils->IndexAt(typeDictionary()->PointerTo(luaTypes.TValue),
-   setnils->        Load("ra"),
-   setnils->        ConstInt32(1));
+   setnils->Store("ra",
+   setnils->      IndexAt(typeDictionary()->PointerTo(luaTypes.TValue),
+   setnils->              Load("ra"),
+   setnils->              ConstInt32(1)));
 
    return true;
 }

--- a/lvjit/LuaFunctionBuilder.cpp
+++ b/lvjit/LuaFunctionBuilder.cpp
@@ -167,8 +167,6 @@ StkId vm_settable(lua_State* L, Instruction i) {
 StkId vm_newtable(lua_State* L, Instruction i) {
    // prologue
    CallInfo *ci = L->ci;
-   LClosure *cl = clLvalue(ci->func);
-   TValue *k = cl->p->k;
    StkId base = ci->u.l.base;
    StkId ra = RA(i);
 
@@ -366,8 +364,6 @@ StkId vm_shr(lua_State* L, Instruction i) {
 StkId vm_unm(lua_State* L, Instruction i) {
    // prologue
    CallInfo *ci = L->ci;
-   LClosure *cl = clLvalue(ci->func);
-   TValue *k = cl->p->k;
    StkId base = ci->u.l.base;
    StkId ra = RA(i);
 
@@ -392,8 +388,6 @@ StkId vm_unm(lua_State* L, Instruction i) {
 StkId vm_bnot(lua_State* L, Instruction i) {
    // prologue
    CallInfo *ci = L->ci;
-   LClosure *cl = clLvalue(ci->func);
-   TValue *k = cl->p->k;
    StkId base = ci->u.l.base;
    StkId ra = RA(i);
 
@@ -414,8 +408,6 @@ StkId vm_bnot(lua_State* L, Instruction i) {
 StkId vm_not(lua_State* L, Instruction i) {
    // prologue
    CallInfo *ci = L->ci;
-   LClosure *cl = clLvalue(ci->func);
-   TValue *k = cl->p->k;
    StkId base = ci->u.l.base;
    StkId ra = RA(i);
 
@@ -431,8 +423,6 @@ StkId vm_not(lua_State* L, Instruction i) {
 StkId vm_len(lua_State* L, Instruction i) {
    // prologue
    CallInfo *ci = L->ci;
-   LClosure *cl = clLvalue(ci->func);
-   TValue *k = cl->p->k;
    StkId base = ci->u.l.base;
    StkId ra = RA(i);
 
@@ -446,8 +436,6 @@ StkId vm_len(lua_State* L, Instruction i) {
 int32_t vm_test(lua_State* L, Instruction i) {
    // prologue
    CallInfo *ci = L->ci;
-   LClosure *cl = clLvalue(ci->func);
-   TValue *k = cl->p->k;
    StkId base = ci->u.l.base;
    StkId ra = RA(i);
    int32_t skipnext = 0;
@@ -467,8 +455,6 @@ int32_t vm_test(lua_State* L, Instruction i) {
 int32_t vm_testset(lua_State* L, Instruction i) {
    // prologue
    CallInfo *ci = L->ci;
-   LClosure *cl = clLvalue(ci->func);
-   TValue *k = cl->p->k;
    StkId base = ci->u.l.base;
    StkId ra = RA(i);
    int32_t skipnext = 0;
@@ -492,8 +478,6 @@ int32_t vm_forloop(lua_State* L, Instruction i) {
    // prologue
    int32_t continueLoop = 0;
    CallInfo *ci = L->ci;
-   LClosure *cl = clLvalue(ci->func);
-   TValue *k = cl->p->k;
    StkId base = ci->u.l.base;
    StkId ra = RA(i);
 
@@ -529,8 +513,6 @@ int32_t vm_forloop(lua_State* L, Instruction i) {
 void vm_forprep(lua_State* L, Instruction i) {
    // prologue
    CallInfo *ci = L->ci;
-   LClosure *cl = clLvalue(ci->func);
-   TValue *k = cl->p->k;
    StkId base = ci->u.l.base;
    StkId ra = RA(i);
 
@@ -818,7 +800,7 @@ bool Lua::FunctionBuilder::buildIL() {
          do_loadk(builder, instruction);
          break;
       case OP_LOADBOOL:
-         do_loadbool(builder, static_cast<TR::IlBuilder*>(bytecodeBuilders[instructionIndex + 2]), instruction);
+         do_loadbool(builder, bytecodeBuilders[instructionIndex + 2], instruction);
          break;
       case OP_LOADNIL:
          do_loadnil(builder, instruction);
@@ -892,19 +874,19 @@ bool Lua::FunctionBuilder::buildIL() {
          nextBuilder = nullptr;
          break;
       case OP_EQ:
-         do_cmp("luaV_equalobj", builder, static_cast<TR::IlBuilder*>(bytecodeBuilders[instructionIndex + 2]), instruction);
+         do_cmp("luaV_equalobj", builder, bytecodeBuilders[instructionIndex + 2], instruction);
          break;
       case OP_LT:
-         do_cmp("luaV_lessthan", builder, static_cast<TR::IlBuilder*>(bytecodeBuilders[instructionIndex + 2]), instruction);
+         do_cmp("luaV_lessthan", builder, bytecodeBuilders[instructionIndex + 2], instruction);
          break;
       case OP_LE:
-         do_cmp("luaV_lessequal", builder, static_cast<TR::IlBuilder*>(bytecodeBuilders[instructionIndex + 2]), instruction);
+         do_cmp("luaV_lessequal", builder, bytecodeBuilders[instructionIndex + 2], instruction);
          break;
       case OP_TEST:
-         do_test(builder, static_cast<TR::IlBuilder*>(bytecodeBuilders[instructionIndex + 2]), instruction);
+         do_test(builder, bytecodeBuilders[instructionIndex + 2], instruction);
          break;
       case OP_TESTSET:
-         do_testset(builder, static_cast<TR::IlBuilder*>(bytecodeBuilders[instructionIndex + 2]), instruction);
+         do_testset(builder, bytecodeBuilders[instructionIndex + 2], instruction);
          break;
       case OP_CALL:
          do_call(builder, instruction);
@@ -914,7 +896,7 @@ bool Lua::FunctionBuilder::buildIL() {
          nextBuilder = nullptr;   // prevent addition of a fallthrough path
          break;
       case OP_FORLOOP:
-         do_forloop(builder, static_cast<TR::IlBuilder*>(bytecodeBuilders[instructionIndex + 1 + GETARG_sBx(instruction)]), instruction);
+         do_forloop(builder, bytecodeBuilders[instructionIndex + 1 + GETARG_sBx(instruction)], instruction);
          break;
       case OP_FORPREP:
          do_forprep(builder, instruction);
@@ -962,7 +944,7 @@ bool Lua::FunctionBuilder::do_loadk(TR::BytecodeBuilder* builder, Instruction in
    return true;
 }
 
-bool Lua::FunctionBuilder::do_loadbool(TR::BytecodeBuilder* builder, TR::IlBuilder* dest, Instruction instruction) {
+bool Lua::FunctionBuilder::do_loadbool(TR::BytecodeBuilder* builder, TR::BytecodeBuilder* dest, Instruction instruction) {
    // setbvalue(ra, GETARG_B(i));
    builder->Call("jit_setbvalue", 2,
    builder->     Load("ra"),
@@ -1347,7 +1329,7 @@ bool Lua::FunctionBuilder::do_jmp(TR::BytecodeBuilder* builder, Instruction inst
    return true;
 }
 
-bool Lua::FunctionBuilder::do_cmp(const char* cmpFunc, TR::BytecodeBuilder* builder, TR::IlBuilder* dest, Instruction instruction) {
+bool Lua::FunctionBuilder::do_cmp(const char* cmpFunc, TR::BytecodeBuilder* builder, TR::BytecodeBuilder* dest, Instruction instruction) {
    /* cmp can be "luaV_equalobj", "luaV_lessthan", or "luaV_lessequal" */
 
    // cmp =  cmpFunc(L, RKB(i), RKC(i));
@@ -1369,7 +1351,7 @@ bool Lua::FunctionBuilder::do_cmp(const char* cmpFunc, TR::BytecodeBuilder* buil
    return true;
 }
 
-bool Lua::FunctionBuilder::do_test(TR::BytecodeBuilder* builder, TR::IlBuilder* dest, Instruction instruction) {
+bool Lua::FunctionBuilder::do_test(TR::BytecodeBuilder* builder, TR::BytecodeBuilder* dest, Instruction instruction) {
    builder->Store("cmp",
    builder->      Call("vm_test", 2,
    builder->           Load("L"),
@@ -1381,7 +1363,7 @@ bool Lua::FunctionBuilder::do_test(TR::BytecodeBuilder* builder, TR::IlBuilder* 
    return true;
 }
 
-bool Lua::FunctionBuilder::do_testset(TR::BytecodeBuilder* builder, TR::IlBuilder* dest, Instruction instruction) {
+bool Lua::FunctionBuilder::do_testset(TR::BytecodeBuilder* builder, TR::BytecodeBuilder* dest, Instruction instruction) {
    builder->Store("cmp",
    builder->      Call("vm_testset", 2,
    builder->           Load("L"),
@@ -1568,7 +1550,7 @@ bool Lua::FunctionBuilder::do_return(TR::BytecodeBuilder* builder, Instruction i
    return true;
 }
 
-bool Lua::FunctionBuilder::do_forloop(TR::BytecodeBuilder* builder, TR::IlBuilder* loopStart, Instruction instruction) {
+bool Lua::FunctionBuilder::do_forloop(TR::BytecodeBuilder* builder, TR::BytecodeBuilder* loopStart, Instruction instruction) {
    int raIndex = GETARG_A(instruction);
    TR::IlValue *index = jit_R(builder, raIndex);
    TR::IlValue *limit = jit_R(builder, raIndex + 1);

--- a/lvjit/LuaFunctionBuilder.hpp
+++ b/lvjit/LuaFunctionBuilder.hpp
@@ -46,7 +46,7 @@ public:
 
     bool do_move(TR::BytecodeBuilder* builder, Instruction instruction);
     bool do_loadk(TR::BytecodeBuilder* builder, Instruction instruction);
-    bool do_loadbool(TR::BytecodeBuilder* builder, TR::IlBuilder* dest, Instruction instruction);
+    bool do_loadbool(TR::BytecodeBuilder* builder, TR::BytecodeBuilder* dest, Instruction instruction);
     bool do_loadnil(TR::BytecodeBuilder* builder, Instruction instruction);
 
     bool do_gettabup(TR::BytecodeBuilder* builder, Instruction instruction);
@@ -72,14 +72,14 @@ public:
     bool do_len(TR::BytecodeBuilder* builder, Instruction instruction);
 
     bool do_jmp(TR::BytecodeBuilder* builder, Instruction instruction);
-    bool do_cmp(const char* cmpFunc, TR::BytecodeBuilder* builder, TR::IlBuilder* dest, Instruction instruction);
-    bool do_test(TR::BytecodeBuilder* builder, TR::IlBuilder* dest, Instruction instruction);
-    bool do_testset(TR::BytecodeBuilder* builder, TR::IlBuilder* dest, Instruction instruction);
+    bool do_cmp(const char* cmpFunc, TR::BytecodeBuilder* builder, TR::BytecodeBuilder* dest, Instruction instruction);
+    bool do_test(TR::BytecodeBuilder* builder, TR::BytecodeBuilder* dest, Instruction instruction);
+    bool do_testset(TR::BytecodeBuilder* builder, TR::BytecodeBuilder* dest, Instruction instruction);
 
     bool do_call(TR::BytecodeBuilder* builder, Instruction instruction);
     bool do_return(TR::BytecodeBuilder* builder, Instruction instruction);
 
-    bool do_forloop(TR::BytecodeBuilder* builder, TR::IlBuilder* loopStart, Instruction instruction);
+    bool do_forloop(TR::BytecodeBuilder* builder, TR::BytecodeBuilder* loopStart, Instruction instruction);
     bool do_forprep(TR::BytecodeBuilder* builder, Instruction instruction);
 
     // convenience functions ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lvjit/LuaFunctionBuilder.hpp
+++ b/lvjit/LuaFunctionBuilder.hpp
@@ -88,24 +88,22 @@ public:
     These functions generate IL builders that are equivalent to the expansion of
     corresponding macros defined in the Lua VM.
     */
-    
     void jit_setobj(TR::BytecodeBuilder* builder, TR::IlValue* obj1, TR::IlValue* obj2);
-
-    TR::IlValue* jit_R(TR::BytecodeBuilder* builder, int arg);
-
-    TR::IlValue* jit_RK(TR::BytecodeBuilder* builder, int arg); // equivalent to RKB and RKC in `lua/lvm.c`
-    
-    TR::IlValue* jit_clLvalue(TR::IlBuilder* builder, TR::IlValue* func);
-
     void jit_Protect(TR::IlBuilder* builder); // updates local copies of values in case of stack reallocation
-
-    TR::IlValue* jit_checktag(TR::IlBuilder* builder, TR::IlValue* value, int type);
-    TR::IlValue* jit_masktag(TR::IlBuilder* builder, TR::IlValue* value, int type);
-
-    TR::IlValue* jit_tonumber(TR::IlBuilder* builder, TR::IlValue* value);
+    TR::IlValue* jit_R(TR::BytecodeBuilder* builder, int arg);
+    TR::IlValue* jit_K(TR::BytecodeBuilder* builder, int arg);
+    TR::IlValue* jit_RK(TR::BytecodeBuilder* builder, int arg); // equivalent to RKB and RKC in `lua/lvm.c`
+    TR::IlValue* jit_clLvalue(TR::IlBuilder* builder, TR::IlValue* func);
+    TR::IlValue* jit_checktag(TR::IlBuilder* builder, TR::IlValue* value, TR::IlValue* type);
+    TR::IlValue* jit_tonumber(TR::IlBuilder* builder, TR::IlValue* value, TR::IlValue* type);
+    TR::IlValue* jit_isinteger(TR::IlBuilder* builder, TR::IlValue* type);
+    TR::IlValue* jit_isnumber(TR::IlBuilder* builder, TR::IlValue* type);
 
 private:
     Proto* prototype;
+    TR::IlValue *intType;
+    TR::IlValue *fltType;
+    TR::IlValue *numType;
     TypeDictionary::LuaTypes luaTypes;
 };
 

--- a/test/opcode/loads.lua
+++ b/test/opcode/loads.lua
@@ -44,8 +44,8 @@ local function loadconst_3() return 3 end
   -- exercises LOADK
 local function return2vals() return 1, 2 end
   -- exercises LOADK (mostly to test returning more than one value)
-local function loadnil() return nil end
-  -- exercises LOADNIL
+local function loadnils() local a = 1; local b,c,d; local e = 2; return a,b,c,d,e end
+  -- exercises LOADNIL (ensures unitiailized locals get a value of nil)
 local function loadbool_true() return true end
   -- exercises LOADBOOL
 
@@ -58,8 +58,13 @@ local a,b = return2vals()
 assert_equal(1, a, "first value of return2vals()")
 assert_equal(2, b, "second value of return2vals()")
 
-assert_compile(loadnil, "loadnil")
-assert_equal(nil, loadnil(), "loadnil()")
+assert_compile(loadnils, "loadnils")
+local a,b,c,d,e = loadnils()
+assert_equal(1, a, "first value of loadnils()")
+assert_equal(nil, b, "second value of loadnils()")
+assert_equal(nil, c, "third value of loadnils()")
+assert_equal(nil, d, "fourth value of loadnils()")
+assert_equal(2, e, "fifth value of loadnils()")
 
 assert_compile(loadbool_true, "loadbool_true")
 assert_equal(true, loadbool_true(), "loadbool_true()")


### PR DESCRIPTION
1. Create IL for loops where index, step and limit are all integers.  If any of them are not fall back to the helper.
2. I noticed that I introduced a warning by copying code from another opcode when working on for loops.  To resolve these issues in a few places I changed the parameter of functions to be a TR::BytecodeBuilder instead of TR::IlBuilder
3. Clean up variable names, etc in do_div so it matches the code in do_math.  It could eventually share the do_math code if it makes sense.
4. In some op_odes the type of an object is used multiple times.  Fetch it at the beginning and use the same  ILValue throughout to improve code generation and make it easier for the compiler to optimize
5. The load nil opcde was not setting all of the registers to nil but rather setting the first register to nil n times.  This change resolves the issue and modifies the tests to verify this change.