### PR TITLE
Update to the latest OMR so OS X will compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ all: $(LUAV)
 
 
 $(LUAV): $(LUA_DIR)/lua.o $(LUA_LIBPATH) $(LVJIT_LIBPATH) $(JITBUILDER_LIBPATH)
-	$(CXX) -o $@ $(LUA_DIR)/lua.o $(LUA_LIBPATH) $(LVJIT_LIBPATH) $(JITBUILDER_LIBPATH) -ldl -lm -Wl,-E -lreadline
+	$(CXX) -o $@ $(LUA_DIR)/lua.o $(LUA_LIBPATH) $(LVJIT_LIBPATH) $(JITBUILDER_LIBPATH) -ldl -lm -lreadline
 
 $(LUA_DIR)/lua.o:
 	cd $(LUA_DIR) && $(MAKE) lua.o SYSCFLAGS="-DLUA_USE_LINUX" MYCFLAGS="$(LUA_BUILD_CONFIG_FLAGS)"


### PR DESCRIPTION
Clang does not appear to understand the -Wl,-E argument so I am
removing it.

With the latest OMR I have verified that OS X now builds correctly
and passes all of the tests in the test folder.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>